### PR TITLE
Fix WSP folding before attribute values

### DIFF
--- a/lib/Email/MIME/ContentType.pm
+++ b/lib/Email/MIME/ContentType.pm
@@ -71,7 +71,7 @@ sub _parse_attributes {
         s/^;//;
         s/^\s+// and next;
         s/\s+$//;
-        unless (s/^([^$tspecials]+)=//) {
+        unless (s/^([^$tspecials]+)=\s*//) {
           # We check for $_'s truth because some mail software generates a
           # Content-Type like this: "Content-Type: text/plain;"
           # RFC 1521 section 3 says a parameter must exist if there is a

--- a/t/1.t
+++ b/t/1.t
@@ -28,6 +28,20 @@ my %ct_tests = (
                                 'boundary' => '----------=_1026452699-10321-0'
                               }
            },
+    'multipart/report; boundary= "=_0c5bb6a163fe08545fb49e4a=73e476c3-cd5a-5ba3-b910-2e1563f157b8_="' => {
+            'type' => 'multipart',
+            'subtype' => 'report',
+            'attributes' => {
+                'boundary' => '=_0c5bb6a163fe08545fb49e4a=73e476c3-cd5a-5ba3-b910-2e1563f157b8_='
+            }
+    },
+    'multipart/report; boundary=' . " \t" . '"=_0c5bb6a163fe08545fb49e4a=73e476c3-cd5a-5ba3-b910-2e1563f157b8_="' => {
+            'type' => 'multipart',
+            'subtype' => 'report',
+            'attributes' => {
+                'boundary' => '=_0c5bb6a163fe08545fb49e4a=73e476c3-cd5a-5ba3-b910-2e1563f157b8_='
+            }
+    }
 );
 
 for (sort keys %ct_tests) {


### PR DESCRIPTION
Some mailservers do a line folding within the Content-Type parameters (see below or the tests).

For example:
> boundary=
>     "=_0c5bb6a1"

[RFC2822](http://tools.ietf.org/html/rfc2822#section-2.2.3) mentions that a folding after higher-level syntactic breaks is allowed. The "=" within attributes seems to be interpreted as such as well.

The fix removes optional whitespaces after the equal sign.