### PR TITLE
Fix problems in new v1.019 trial version

### DIFF
--- a/lib/Email/MIME/ContentType.pm
+++ b/lib/Email/MIME/ContentType.pm
@@ -92,10 +92,10 @@ sub parse_content_type {
 
 sub _clean_comments {
     my $ret = ($_[0] =~ s/^\s+//);
-    while (length $_) {
+    while (length $_[0]) {
         last unless $_[0] =~ s/^\(//;
         my $level = 1;
-        while (length $_) {
+        while (length $_[0]) {
             my $ch = substr $_[0], 0, 1, '';
             if ($ch eq '(') {
                 $level++;

--- a/lib/Email/MIME/ContentType.pm
+++ b/lib/Email/MIME/ContentType.pm
@@ -76,7 +76,13 @@ sub parse_content_type {
 
     _clean_comments($ct);
     $ct =~ s/\s+$//;
-    my $attributes = _process_rfc2231(_parse_attributes($ct));
+
+    my $attributes = {};
+    if ($STRICT_PARAMS and length $ct and $ct !~ /^;/) {
+        carp "Missing semicolon before first Content-Type parameter '$ct'";
+    } else {
+        $attributes = _process_rfc2231(_parse_attributes($ct));
+    }
 
     return {
         type       => $type,
@@ -150,6 +156,7 @@ sub _process_rfc2231 {
 
 sub _parse_attributes {
     local $_ = shift;
+    substr($_, 0, 0, '; ') if length $_ and $_ !~ /^;/;
     my $attribs = {};
     while (length $_) {
         s/^;// or $STRICT_PARAMS and do {

--- a/t/1.t
+++ b/t/1.t
@@ -154,6 +154,7 @@ sub test {
     $expect->{discrete}  = $expect->{type};
     $expect->{composite} = $expect->{subtype};
 
+    local $_;
     is_deeply(parse_content_type($string), $expect, $info);
 }
 


### PR DESCRIPTION
* Used incorrect variable in _clean_comments (and thanks to `for` usage in tests, those tests passed)
* Fix breakage of Email::MIME module as it uses **private** method _parse_attributes