### PR TITLE
Add new function parse_content_disposition which parse Content-Disposition

### DIFF
--- a/lib/Email/MIME/ContentType.pm
+++ b/lib/Email/MIME/ContentType.pm
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 package Email::MIME::ContentType;
-# ABSTRACT: Parse a MIME Content-Type Header
+# ABSTRACT: Parse a MIME Content-Type or Content-Disposition Header
 
 use Carp;
 use Encode 2.87 qw(find_mime_encoding);
@@ -41,6 +41,20 @@ our @EXPORT = qw(parse_content_type parse_content_disposition);
     subtype    => "x-stuff",
     attributes => {
       title => "This is even more ***fun*** isn't it!"
+    }
+  };
+
+  # Content-Disposition: attachment; filename=genome.jpeg;
+  #   modification-date="Wed, 12 Feb 1997 16:29:51 -0500"
+  my $cd = q(attachment; filename=genome.jpeg;
+    modification-date="Wed, 12 Feb 1997 16:29:51 -0500");
+  my $data = parse_content_disposition($cd);
+
+  $data = {
+    type       => "attachment",
+    attributes => {
+      filename            => "genome.jpeg",
+      "modification-date" => "Wed, 12 Feb 1997 16:29:51 -0500"
     }
   };
 
@@ -301,6 +315,14 @@ For backward compatibility with a really unfortunate misunderstanding of RFC
 also present in the returned hashref, with the values of C<type> and C<subtype>
 respectively.
 
+=func parse_content_disposition
+
+This routine is exported by default.
+
+This routine parses email Content-Disposition headers according to RFC 2183 and
+RFC 2231.  It returns a hash as above, with entries for the C<type>, and a hash
+of C<attributes>.
+
 =head1 WARNINGS
 
 This is not a valid content-type header, according to both RFC 1521 and RFC
@@ -312,5 +334,7 @@ If a semicolon appears, a parameter must.  C<parse_content_type> will carp if
 it encounters a header of this type, but you can suppress this by setting
 C<$Email::MIME::ContentType::STRICT_PARAMS> to a false value.  Please consider
 localizing this assignment!
+
+Same applies for C<parse_content_disposition>.
 
 =cut

--- a/t/parse_content_disposition.t
+++ b/t/parse_content_disposition.t
@@ -1,0 +1,86 @@
+# vim:ft=perl
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+BEGIN { use_ok('Email::MIME::ContentType'); }
+
+my %cd_tests = (
+    '' => { type => 'attachment', attributes => {} },
+    'inline' => { type => 'inline', attributes => {} },
+    'attachment' => { type => 'attachment', attributes => {} },
+
+    'attachment; filename=genome.jpeg; modification-date="Wed, 12 Feb 1997 16:29:51 -0500"' => {
+        type => 'attachment',
+        attributes => {
+            filename => 'genome.jpeg',
+            'modification-date' => 'Wed, 12 Feb 1997 16:29:51 -0500'
+        }
+    },
+
+    q(attachment; filename*=UTF-8''genome.jpeg; modification-date="Wed, 12 Feb 1997 16:29:51 -0500") => {
+        type => 'attachment',
+        attributes => {
+            filename => 'genome.jpeg',
+            'modification-date' => 'Wed, 12 Feb 1997 16:29:51 -0500'
+        }
+    },
+
+    q(attachment; filename*0*=us-ascii'en'This%20is%20even%20more%20; filename*1*=%2A%2A%2Afun%2A%2A%2A%20; filename*2="isn't it!") => {
+        type => 'attachment',
+        attributes => {
+            filename => "This is even more ***fun*** isn't it!"
+        }
+    },
+
+    q(attachment; filename*0*='en'This%20is%20even%20more%20; filename*1*=%2A%2A%2Afun%2A%2A%2A%20; filename*2="isn't it!") => {
+        type => 'attachment',
+        attributes => {
+            filename => "This is even more ***fun*** isn't it!"
+        }
+    },
+
+    q(attachment; filename*0*=''This%20is%20even%20more%20; filename*1*=%2A%2A%2Afun%2A%2A%2A%20; filename*2="isn't it!") => {
+        type => 'attachment',
+        attributes => {
+            filename => "This is even more ***fun*** isn't it!"
+        }
+    },
+
+    q(attachment; filename*0*=us-ascii''This%20is%20even%20more%20; filename*1*=%2A%2A%2Afun%2A%2A%2A%20; filename*2="isn't it!") => {
+        type => 'attachment',
+        attributes => {
+            filename => "This is even more ***fun*** isn't it!"
+        }
+    },
+);
+
+my %non_strict_cd_tests = (
+    'attachment; filename=genome.jpeg; modification-date="Wed, 12 Feb 1997 16:29:51 -0500";' => {
+        type => 'attachment',
+        attributes => {
+            filename => 'genome.jpeg',
+            'modification-date' => 'Wed, 12 Feb 1997 16:29:51 -0500'
+        }
+    },
+);
+
+sub test {
+    my ($string, $expect, $info) = @_;
+    local $_;
+    $info =~ s/\r/\\r/g;
+    $info =~ s/\n/\\n/g;
+    is_deeply(parse_content_disposition($string), $expect, $info);
+}
+
+for (sort keys %cd_tests) {
+    test($_, $cd_tests{$_}, "Can parse C-D <$_>");
+}
+
+local $Email::MIME::ContentType::STRICT_PARAMS = 0;
+for (sort keys %cd_tests) {
+    test($_, $cd_tests{$_}, "Can parse non-strict C-D <$_>");
+}
+for (sort keys %non_strict_cd_tests) {
+    test($_, $non_strict_cd_tests{$_}, "Can parse non-strict C-D <$_>");
+}


### PR DESCRIPTION
Module Email::MIME uses private function _parse_attributes for parsing
Content-Disposition header. So this new function can help Email::MIME to
stop using private Email::MIME::ContentType functions.