### PR TITLE
Fix: Use of uninitialized value in pattern match (m//) at lib/Email/MIME/ContentType.pm line 204.

### DIFF
--- a/lib/Email/MIME/ContentType.pm
+++ b/lib/Email/MIME/ContentType.pm
@@ -201,7 +201,7 @@ sub _process_rfc2231 {
     foreach (keys %{$attribs}) {
         next unless $_ =~ m/^(.*)\*$/;
         my $key = $1;
-        next unless $attribs->{$_} =~ m/^$re_exvalue$/;
+        next unless defined $attribs->{$_} and $attribs->{$_} =~ m/^$re_exvalue$/;
         my ($charset, $value) = ($1, $2);
         $value =~ s/%([0-9A-Fa-f]{2})/pack('C', hex($1))/eg;
         if (length $charset) {


### PR DESCRIPTION
It happens on following input:

  use Email::MIME::ContentType;
  parse_content_type('text/plain; param*=value/');