### PR TITLE
Prevent warnings "Use of uninitialized value $_"

### DIFF
--- a/lib/Email/MIME/ContentType.pm
+++ b/lib/Email/MIME/ContentType.pm
@@ -220,6 +220,7 @@ sub _process_rfc2231 {
 
 sub _parse_attributes {
     local $_ = shift;
+    return {} unless $_;
     substr($_, 0, 0, '; ') if length $_ and $_ !~ /^;/;
     my $attribs = {};
     while (length $_) {


### PR DESCRIPTION
 - when _parse_attributes is called with empty param.

I get these a lot in the TDC webmail server.

Best regards, Olav Cleemann